### PR TITLE
Support for specifying which size(s) of Media to fetch

### DIFF
--- a/Sources/OpenAlpha/Internal/Models/FetchableSize.swift
+++ b/Sources/OpenAlpha/Internal/Models/FetchableSize.swift
@@ -1,0 +1,13 @@
+//
+//  FetchableSize.swift
+//  
+//
+//  Created by Cole Roberts on 1/21/23.
+//
+
+import Foundation
+
+protocol FetchableSize: AnyObject {
+    /// Begins asynchronously fetching content for the given sizes (`Media.Size`)
+    func fetch(sizes: [Media.Size]) async throws
+}

--- a/Sources/OpenAlpha/Internal/Providers/MediaProvider.swift
+++ b/Sources/OpenAlpha/Internal/Providers/MediaProvider.swift
@@ -18,7 +18,7 @@ protocol MediaProviding {
     ///   - from: The IPv4 address to retrieve media from.
     /// - Returns: An array of `Media` objects.
     /// - Throws: An error if the retrieval fails.
-    func media(from ip: String) async throws -> [Media]
+    func media(sizes: [Media.Size], from ip: String) async throws -> [Media]
 }
 
 // MARK: - `MediaProvider` -
@@ -39,7 +39,7 @@ final class MediaProvider: MediaProviding {
     
     // MARK: - `Public Methods` -
     
-    func media(from ip: String) async throws -> [Media] {
+    func media(sizes: [Media.Size], from ip: String) async throws -> [Media] {
         do {
             let _ = try await DLNA.StartAction(ip: ip).request(with: session)
             let _ = try await DLNA.GetPushRootAction(ip: ip).request(with: session)
@@ -49,7 +49,7 @@ final class MediaProvider: MediaProviding {
             let media = items.compactMap(Media.init)
             
             for item in media {
-                try await item.fetch()
+                try await item.fetch(sizes: sizes)
             }
             
             _ = try await DLNA.EndAction(ip: ip).request(with: session)

--- a/Sources/OpenAlpha/Public/OpenAlpha.swift
+++ b/Sources/OpenAlpha/Public/OpenAlpha.swift
@@ -12,10 +12,13 @@ import Foundation
 public protocol OACore: AnyObject {
     /// Asynchronously retrieves an array of `Media` objects from the given IPv4 address.
     /// - Parameters:
+    ///   - sizes: An array of sizes (`Media.Size`) to request, to request all available sizes utilize `media(sizes: Media.Size.all(), ...)`.
+    ///   It's worth noting that `Asset.original` may be a large request, utilizing more battery from the camera. If you prefer to avoid a larger data task,
+    ///   and don't need the high-resolution image, opt to pass in `.large` instead.
     ///   - from: The IPv4 address to retrieve media from.
     /// - Returns: An array of `Media` objects.
     /// - Throws: An error if the retrieval fails.
-    func media(from ip: String) async throws -> [Media]
+    func media(sizes: [Media.Size], from ip: String) async throws -> [Media]
 }
 
 public protocol OAHotspotConnectable: AnyObject {
@@ -62,12 +65,8 @@ public final class OpenAlpha {
 // MARK: - `OpenAlpha+OACore` -
 
 extension OpenAlpha: OACore {
-    public func media(from ip: String) async throws -> [Media] {
-        do {
-            return try await mediaProvider.media(from: ip)
-        } catch {
-            throw error
-        }
+    public func media(sizes: [Media.Size], from ip: String) async throws -> [Media] {
+        try await mediaProvider.media(sizes: sizes, from: ip)
     }
 }
 


### PR DESCRIPTION
# Summary

This work requires a consumer to pass in the desired sizes (`Media.Size`) of media to fetch. This has the added benefit of making _less_ network requests under the hood and provides a more nuanced approach to asset retrieval.

Now, to fetch available sizes, a consumer might call:

```swift
openAlpha.media(sizes: [.small, .large], from: "127.0.0.1")
```

And to request all sizes:

```swift
openAlpha.media(sizes: .all(), from: "127.0.0.1")
```

>Note: It's worth noting that `.all()` may incur an additional cost if an `Asset.original` URL is requested. Generally speaking, this data may represent the original high-resolution photo, and may be much larger in both resolution and file size than even `.large`.